### PR TITLE
Fix path traversal in bundle extraction and Anthropic message ordering

### DIFF
--- a/packages/api/src/utils/bundle.ts
+++ b/packages/api/src/utils/bundle.ts
@@ -7,6 +7,7 @@ import { gunzipSync } from "node:zlib";
 /**
  * Extract files from a .agent bundle (tar.gz).
  * Returns a map of filename → content as string.
+ * Skips entries with path traversal (e.g., "../") or absolute paths.
  */
 export function extractFiles(gzBuffer: Buffer): Record<string, string> {
   const tarBuffer = gunzipSync(gzBuffer);
@@ -30,7 +31,11 @@ export function extractFiles(gzBuffer: Buffer): Record<string, string> {
 
     // Read content
     const content = tarBuffer.subarray(offset, offset + size);
-    files[fileName] = content.toString("utf-8");
+
+    // Skip entries with path traversal or absolute paths
+    if (!fileName.startsWith("/") && !fileName.includes("..")) {
+      files[fileName] = content.toString("utf-8");
+    }
 
     // Skip to next 512-byte boundary
     const padding = (512 - (size % 512)) % 512;
@@ -56,6 +61,10 @@ export function extractBundleToDisk(gzBuffer: Buffer): {
 
   for (const [name, content] of Object.entries(files)) {
     const filePath = join(dir, name);
+    // Verify the resolved path is still within the target directory
+    if (!filePath.startsWith(dir)) {
+      continue;
+    }
     const fileDir = dirname(filePath);
     if (!existsSync(fileDir)) {
       mkdirSync(fileDir, { recursive: true });

--- a/packages/runtime/src/llm/providers/anthropic.ts
+++ b/packages/runtime/src/llm/providers/anthropic.ts
@@ -12,26 +12,31 @@ export class AnthropicProvider implements LLMProvider {
   async call(request: LLMCallRequest): Promise<LLMCallResponse> {
     const messages: Anthropic.MessageParam[] = [];
 
-    // User message
-    messages.push({ role: "user", content: request.userMessage });
-
-    // Tool results from previous iteration
+    // Tool results from previous iteration — build conversation history:
+    // [user(message), assistant(tool_use), user(tool_result)]
     if (request.toolResults?.length) {
-      // Add assistant message with tool_use blocks, then user message with tool_result blocks
+      // Original user message
+      messages.push({ role: "user", content: request.userMessage });
+
+      // Assistant message with tool_use blocks
       const toolUseBlocks: Anthropic.ContentBlockParam[] = request.toolResults.map((tr) => ({
         type: "tool_use" as const,
         id: tr.id ?? tr.name,
         name: tr.name,
         input: {},
       }));
-      messages.splice(messages.length - 1, 0, { role: "assistant", content: toolUseBlocks });
+      messages.push({ role: "assistant", content: toolUseBlocks });
 
+      // User message with tool_result blocks
       const toolResultContent: Anthropic.ToolResultBlockParam[] = request.toolResults.map((tr) => ({
         type: "tool_result" as const,
         tool_use_id: tr.id ?? tr.name,
         content: tr.result,
       }));
       messages.push({ role: "user", content: toolResultContent });
+    } else {
+      // No tool results — simple user message
+      messages.push({ role: "user", content: request.userMessage });
     }
 
     // Map tools


### PR DESCRIPTION
## Summary

### Security: Path traversal in bundle extraction
- **`packages/api/src/utils/bundle.ts`** — `extractFiles()` now skips tar entries containing `..` (path traversal) or starting with `/` (absolute paths), preventing a Zip Slip–style vulnerability where a malicious agent bundle could write files outside the intended directory.
- **`extractBundleToDisk()`** adds a secondary check that the resolved `join(dir, name)` path remains within the target directory before writing to disk.

### Bug fix: Anthropic provider message ordering
- **`packages/runtime/src/llm/providers/anthropic.ts`** — When tool results from a previous iteration are present, the message array was built as `[assistant(tool_use), user(message), user(tool_result)]` via `splice`. This violates the Anthropic API requirement that conversations **start with a user message**. Fixed to `[user(message), assistant(tool_use), user(tool_result)]` using straightforward `push` calls instead of `splice`.

## Test plan
- [x] All 154 tests pass across all 4 packages (`pnpm -r test`)
- [x] Build passes (`pnpm -r build`)
- [x] Bundle extraction path traversal blocked for `../` and `/` prefixed entries
- [x] Bundle extraction path traversal blocked for entries that resolve outside target dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)