### PR TITLE
docs(cli): add PowerShell curl examples for Windows users

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,5 +1,7 @@
 # CLI Reference
 
+> **Windows (PowerShell):** use `curl.exe` instead of `curl`. PowerShell aliases `curl` to `Invoke-WebRequest`, which breaks the shell examples below. For JSON request bodies, prefer a file input such as `curl.exe ... -d "@input.json"`.
+
 ## skrun init
 
 Create a new Skrun agent.
@@ -198,4 +200,28 @@ skrun deploy       # npx installs MCP server at runtime
 # Edit SKILL.md or agent.yaml
 skrun test         # Verify changes
 skrun deploy       # Re-deploy (bump version in agent.yaml first)
+```
+
+### Test POST /run from PowerShell
+```powershell
+$body = @{
+  input = "Audit this landing page for SEO issues"
+} | ConvertTo-Json
+
+$body | Set-Content -Path input.json
+curl.exe -X POST http://localhost:3000/run `
+  -H "Content-Type: application/json" `
+  -d "@input.json"
+```
+
+### Call a deployed agent from PowerShell
+```powershell
+$body = @{
+  input = "Summarize the latest changelog entry"
+} | ConvertTo-Json
+
+$body | Set-Content -Path input.json
+curl.exe -X POST https://your-agent.example/run `
+  -H "Content-Type: application/json" `
+  -d "@input.json"
 ```


### PR DESCRIPTION
## What does this PR do?

The CLI reference (docs/cli.md) only shows Unix curl shell examples. On Windows, PowerShell aliases \curl\ to \Invoke-WebRequest\, which silently breaks every shell example when copy-pasted.

This PR:
- Adds a tip block at the top of the CLI reference noting the \curl\ alias issue and recommending \curl.exe\ with a file-based JSON body for PowerShell.
- Adds two PowerShell-specific code blocks at the end of the doc showing how to call a local agent and a deployed agent using \curl.exe\ + \ConvertTo-Json\ + a temp file.

## Checklist

- [ ] Tests added/updated
- [x] \pnpm build\ passes
- [x] \pnpm test\ passes
- [x] \pnpm lint\ passes